### PR TITLE
Bug fixes and new limit/offset feature

### DIFF
--- a/node_adt.js
+++ b/node_adt.js
@@ -124,8 +124,10 @@ var Adt = function() {
     }
 
     // Handle non-empty tables
-    for(var i=0; i < _this.header.recordCount; i++) {
-      var start  = _this.header.dataOffset + _this.header.recordLength * i;
+    readNextRecord(); // start with the first record
+
+    function readNextRecord() {
+      var start  = _this.header.dataOffset + _this.header.recordLength * iteratedCount;
       var end    = start + _this.header.recordLength;
       var length = end - start;
       var tempBuffer = new Buffer(length);
@@ -148,10 +150,16 @@ var Adt = function() {
         }
 
         iteratedCount++;
-        if ((iteratedCount === _this.header.recordCount) && (typeof callback === 'function'))
-          callback(null, _this);
+        if (iteratedCount < _this.header.recordCount) {
+          readNextRecord();
+        }
+        else {
+          if (typeof callback === 'function') {
+            callback(null, _this);
+          }
+        }
       });
-    }
+    } // function readOneRecord
   }
 
   this.findRecord = function(recordNumber, callback) {

--- a/node_adt.js
+++ b/node_adt.js
@@ -192,7 +192,7 @@ var Adt = function() {
 
   this.close = function() {
     if (this.fd) {
-      fs.close(this.fd);
+      fs.close(this.fd, function () {/* no-op */});
       this.fd = null;
     }
   };

--- a/node_adt.js
+++ b/node_adt.js
@@ -133,7 +133,15 @@ var Adt = function() {
       var tempBuffer = new Buffer(length);
 
       fs.read(_this.fd, tempBuffer, 0, length, start, function(err, bytes, buffer) {
-        if (err) return callback(err, _this);
+        if (err) {
+          if (typeof callback === 'function') {
+            return callback(err, _this);
+          }
+          else {
+            // An error occurred but no callback was given, so raise an 'uncaughtException' event
+            throw new Error(err);
+          }
+        }
 
         var record = null;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,222 @@
+{
+  "name": "node_adt",
+  "version": "1.1.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "requires": {
+        "null-check": "1.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "type": "git",
     "url": "git://github.com/albertzak/node_adt.git"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "node_adt.js",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha test/test.js"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "iconv-lite": "^0.4.11"
   },
   "devDependencies": {
-    "mocha": "^2.3.2"
+    "mocha": "^5.2.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -224,6 +224,11 @@ describe('Adt', function() {
       });
     });
 
+    it('should enumerate records in the order they appear in the adt file', function () {
+      var ids = records.map(function (rec) { return rec.AbrGruId });
+      assert.deepStrictEqual(ids, [1, 2, 4, 5, 6, 8, 10, 37, 39]);
+    });
+
     it('should retrieve field values', function () {
       assert.equal(records[0].AbrGruId, 1);
       assert.equal(records[0].Such, 'WGK');

--- a/test/test.js
+++ b/test/test.js
@@ -218,8 +218,8 @@ describe('Adt', function() {
         assert.equal(err, null);
         adt.eachRecord(function(err, record) {
           records.push(record);
-        }, function() {
-          done();
+        }, function(err) {
+          done(err);
         });
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -207,7 +207,6 @@ describe('Adt', function() {
         done();
       })
     });
-
   });
 
   describe('#eachRecord', function() {
@@ -270,7 +269,96 @@ describe('Adt', function() {
       assert.equal(records[7].MwstGrup, null);
       assert.equal(records[8].MwstGrup, 0);
     });
-
   });
 
+  describe('#eachRecord with options', function() {
+
+    function fetch(options, cb) {
+      var records = [];
+      new Adt().open(fixture, 'ISO-8859-1', function(err, adt) {
+        assert.equal(err, null);
+        adt.eachRecord(options, function(err, record) {
+          records.push(record);
+        }, function(err) {
+          cb(err, records);
+        });
+      });
+    }
+
+    it('should apply limit option', function(done) {
+      fetch({limit: 5}, function (err, records) {
+        if (err) return done(err);
+        assert.equal(err, null);
+        assert.equal(records.length, 5);
+        assert.equal(records[0].AbrGruId, 1);
+        assert.equal(records[0].Such, 'WGK');
+        done();
+      });
+    });
+
+    it('should apply offset option', function(done) {
+      fetch({offset: 3}, function (err, records) {
+        if (err) return done(err);
+        assert.equal(err, null);
+        assert.equal(records.length, 6);
+        assert.equal(records[0].AbrGruId, 5);
+        assert.equal(records[0].Such, 'KFA');
+        done();
+      });
+    });
+
+    it('should apply limit and offset option', function(done) {
+      fetch({offset: 8, limit: 1}, function (err, records) {
+        if (err) return done(err);
+        assert.equal(err, null);
+        assert.equal(records.length, 1);
+        assert.equal(records[0].AbrGruId, 39);
+        assert.equal(records[0].Such, 'PRVL');
+        done();
+      });
+    });
+
+    it('should handle limit option underflow', function(done) {
+      fetch({limit: -1}, function (err, records) {
+        if (err) return done(err);
+        assert.equal(err, null);
+        assert.equal(records.length, 0);
+        done();
+      });
+    });
+
+    it('should handle limit option overflow', function(done) {
+      fetch({limit: 1000}, function (err, records) {
+        if (err) return done(err);
+        assert.equal(err, null);
+        assert.equal(records.length, 9);
+        assert.equal(records[0].AbrGruId, 1);
+        assert.equal(records[0].Such, 'WGK');
+        assert.equal(records[8].AbrGruId, 39);
+        assert.equal(records[8].Such, 'PRVL');
+        done();
+      });
+    });
+
+    it('should handle offset option underflow', function(done) {
+      fetch({offset: -1}, function (err, records) {
+        if (err) return done(err);
+        assert.equal(err, null);
+        assert.equal(records.length, 9);
+        assert.equal(records[0].AbrGruId, 1);
+        assert.equal(records[0].Such, 'WGK');
+        done();
+      });
+    });
+
+    it('should handle offset option overflow', function(done) {
+      fetch({offset: 1000}, function (err, records) {
+        if (err) return done(err);
+        assert.equal(err, null);
+        assert.equal(records.length, 0);
+        done();
+      });
+    });
+
+  });
 });


### PR DESCRIPTION
Hi @albertzak,

We still use this module, and I made a few bugfixes and add a new feature. I'm sending you the changes in hopes that you wish to merge them and publish a new version to npm.

Here are the details:
- [x] Update `mocha` to a new version. The old version had a few vulnerability warnings.
- [x] Commit the npm lockfile
- [x] Bugfix: ensure `eachRecord` deterministically enumerates records in the order they appear in the adt table. The unit tests assumed a deterministic order, but the implementation was not deterministic. This fixes intermittent test failures where the records came back in a different order to the one assumed. It's a non-breaking change, since clients were given no guarantees about record order before this change, so making the order deterministic doesn't break any guarantees made before. A new test has been added.
- [x] Bugfix: fix deprecation warning coming from Node.js >= 7.0.0. The callback parameter of `fs.close()` is no longer optional. This change just adds a no-op callback.
- [x] Bugfix: in one control path, `eachRecord()` calls `callback` without first checking if it is defined (it's treated as an optional parameter in other control paths). The missing check has been added.
- [x] New feature: `eachRecord()` now optionally accepts an `options` object as the first parameter. This is a non-breaking change - all existing calls to `eachRecord` without the `options` argument work as before. The `options` object can specify `limit` and/or `offset` numeric properties. They can be used to control where enumeration of records starts and ends. Some tests have been added for this feature.
- [x] Minor version bump. There are no breaking changes.
